### PR TITLE
F/#22 Add BookmarkReadDto in presentation layer

### DIFF
--- a/src/core/presentation/dto/bookmarkReadDto.ts
+++ b/src/core/presentation/dto/bookmarkReadDto.ts
@@ -30,7 +30,7 @@ export class BookmarkReadDto {
   }
 
   static fromEntity(bookmark : Bookmark){
-    if (bookmark.id === undefined)
+    if (typeof bookmark.id === 'undefined')
       throw new Error('Bookmark id is undefined')
     return new BookmarkReadDto(bookmark.parentId, bookmark.id, bookmark.title, bookmark.url);
   }

--- a/src/core/presentation/dto/bookmarkReadDto.ts
+++ b/src/core/presentation/dto/bookmarkReadDto.ts
@@ -30,8 +30,8 @@ export class BookmarkReadDto {
   }
 
   static fromEntity(bookmark : Bookmark){
-    if (typeof bookmark.id === 'undefined')
-      throw new Error('Bookmark id is undefined')
+    if (typeof bookmark.id === "undefined")
+      throw new Error("Bookmark id is undefined")
     return new BookmarkReadDto(bookmark.parentId, bookmark.id, bookmark.title, bookmark.url);
   }
 

--- a/src/core/presentation/dto/bookmarkReadDto.ts
+++ b/src/core/presentation/dto/bookmarkReadDto.ts
@@ -1,0 +1,38 @@
+import {Bookmark} from "src/core/domain/bookmark/bookmark";
+
+export class BookmarkReadDto {
+  private _parentId?: string;
+  private _id: string;
+  private _title: string;
+  private _url?: string;
+
+  constructor(parentID: string | undefined, id: string, title: string, url: string | undefined) {
+    this._parentId = parentID
+    this._id = id;
+    this._title = title;
+    this._url = url;
+  }
+
+  get parentId(): string | undefined {
+    return this._parentId;
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get title(): string {
+    return this._title;
+  }
+
+  get url(): string | undefined{
+    return this._url;
+  }
+
+  static fromEntity(bookmark : Bookmark){
+    if (bookmark.id === undefined)
+      throw new Error('Bookmark id is undefined')
+    return new BookmarkReadDto(bookmark.parentId, bookmark.id, bookmark.title, bookmark.url);
+  }
+
+}

--- a/src/core/presentation/dto/bookmarkReadDto.ts
+++ b/src/core/presentation/dto/bookmarkReadDto.ts
@@ -29,9 +29,9 @@ export class BookmarkReadDto {
     return this._url;
   }
 
-  static fromEntity(bookmark : Bookmark){
+  static fromEntity(bookmark : Bookmark) : BookmarkReadDto | undefined{
     if (typeof bookmark.id === "undefined")
-      throw new Error("Bookmark id is undefined")
+      return undefined;
     return new BookmarkReadDto(bookmark.parentId, bookmark.id, bookmark.title, bookmark.url);
   }
 


### PR DESCRIPTION
# Pull Request Check List

- Major Reviewer: @tooktak/clipbook 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context
Resolve : #22 
- FE에서 요청한대로 id는 undefined가 될 수 없게 설정했습니다.
- 도메인 객체에서 DTO 객체로 변환할 때 사용하는 fromEntity 메소드를 추가했습니다.
여기서 도메인 객체의 id는 undefined가 될 수 있어서 예외처리로 빼놨는데, 더 좋은 방법이 있을까요?

TS는 처음 해보기 때문에 틀린부분 알려주시면 고맙습니다!

머지 이후에 Usecase에서 도메인 객체 대신 DTO를 뷰로 전달하게끔 수정할 예정입니다.