### PR TITLE
Refactor global store

### DIFF
--- a/src/client/component/contentScript/App.tsx
+++ b/src/client/component/contentScript/App.tsx
@@ -1,106 +1,17 @@
-import React, { createContext, useEffect, useState } from "react";
+import React from "react";
 import styles from "./App.module.css";
 import BookmarkSidebar from "./BookmarkSidebar/BookmarkSidebar";
 import BookmarkIndicator from "./BookmarkIndicator/BookmarkIndicator";
-
-type Bookmark = {
-  _parentId: string | undefined;
-  _id: string | undefined;
-  _title: string;
-  _url: string | undefined;
-}
-
-type BookmarkListType = {
-  bookmarkList: Bookmark[];
-  getBookmarkList(): void;
-}
-
-type BookmarkSidebarOpenState = {
-  open: boolean;
-  sidebarOpen(): void;
-  sidebarClose(): void;
-}
-
-type OrderBy = "ASC" | "DESC";
-
-type BookmarkOption = {
-  orderBy: OrderBy;
-  showFolder: boolean;
-  open: boolean;
-  handleOrderBy(): void;
-  handleShowFolder(): void;
-  handleOpen(): void;
-  handleClose(): void;
-}
-
-export const Store = {
-  BookmarkOption: createContext<BookmarkOption>({} as BookmarkOption)
-}
-
-export const BookmarkSidebarOpen = createContext<BookmarkSidebarOpenState>({} as BookmarkSidebarOpenState)
-export const BookmarkList = createContext<BookmarkListType>({} as BookmarkListType)
-
+import { ContextProvider } from "src/client/context";
 
 const App: React.FC = () => {
-  const [open, setOpen] = useState<boolean>(false);
-  const [showFolder, setShowFolder] = useState<boolean>(false);
-  const [orderBy, setOrderBy] = useState<OrderBy>("ASC");
-  const [optionOpen, setOptionOpen] = useState<boolean>(true);
-  const [bookmarkList, setBookmarkList] = useState<Bookmark[]>([]);
-
-  const getBookmarkList = () => {
-    // 북마크에 저장된 데이터 chrome storage 에서 불러오기
-    chrome.storage.local.get(['bookmark'], (result) => {
-      // storage 에서 불러온 데이터는 Object 형`태 => Bookmark 로 변환
-      const res = result.bookmark.filter((e: Bookmark) => e._url);
-      setBookmarkList(res);
-    });
-  }
-
-  const sidebarOpen = () => {
-    setOpen(true);
-  }
-
-  const sidebarClose = () => {
-    setOpen(false);
-  }
-
-const handleOptionOpen = () => {
-    setOptionOpen(true)
-  }
-
-  const handleOptionClose = () => {
-    setOptionOpen(false)
-  }
-
-  const handleShowFolder = () => {
-    setShowFolder(!showFolder);
-  }
-
-  const handleOrderBy = () => {
-    if(orderBy === "ASC") {
-      setOrderBy("DESC");
-    } else {
-      setOrderBy("ASC");
-    }
-  }
-
-  
-  useEffect(() => {
-    getBookmarkList();
-  }, [])
-
   return (
-    <BookmarkSidebarOpen.Provider value={{open, sidebarOpen, sidebarClose}}>
-      <Store.BookmarkOption.Provider value={{open: optionOpen, showFolder, orderBy, handleOpen: handleOptionOpen, handleClose: handleOptionClose, handleShowFolder, handleOrderBy}}>
-        <BookmarkList.Provider value={{bookmarkList, getBookmarkList}}>
-          <div className={styles.advancedBookmark}>
-            <BookmarkSidebar />
-            <BookmarkIndicator />
-          </div>
-        </BookmarkList.Provider>
-      </Store.BookmarkOption.Provider>
-    </BookmarkSidebarOpen.Provider>
+    <ContextProvider>
+      <div className={styles.advancedBookmark}>
+        <BookmarkSidebar />
+        <BookmarkIndicator />
+      </div>
+    </ContextProvider>
   );
 };
 

--- a/src/client/component/contentScript/BookmarkIndicator/BookmarkIndicator.tsx
+++ b/src/client/component/contentScript/BookmarkIndicator/BookmarkIndicator.tsx
@@ -1,13 +1,13 @@
-import React, { useContext } from "react";
+import React from "react";
 import styles from "./BookmarkIndicator.module.css";
 import { BookmarkIcon } from "src/client/component/Common/Icon";
-import { BookmarkSidebarOpen } from "src/client/component/contentScript/App";
+import { useBookmarkSidebar } from "src/client/context/UiContext";
 
 const BookmarkIndicator: React.FC = () => {
-  const { sidebarOpen } = useContext(BookmarkSidebarOpen);
+  const { toggleOpen } = useBookmarkSidebar();
 
   return (
-    <div className={`${styles.bookmarkIndicator}`} onClick={sidebarOpen}>
+    <div className={`${styles.bookmarkIndicator}`} onClick={toggleOpen}>
       <BookmarkIcon size="20" />
     </div>
   );

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkHeader/BookmarkHeader.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkHeader/BookmarkHeader.tsx
@@ -1,10 +1,10 @@
-import React, { useContext } from "react";
+import React from "react";
 import styles from "./BookmarkHeader.module.css";
-import { BookmarkList } from "src/client/component/contentScript/App";
 import { SearchIcon, SeeMoreIcon, SortIcon } from "src/client/component/Common/Icon";
+import { useBookmarkListData } from "src/client/context/BookmarkList";
 
 const BookmarkHeader: React.FC = () => {
-  const { bookmarkList } = useContext(BookmarkList);
+  const bookmarkList = useBookmarkListData();
 
   return (
     <div className={styles.bookmarkHeader}>

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkList/BookmarkList.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkList/BookmarkList.tsx
@@ -1,36 +1,21 @@
-import React, { useContext, useEffect, useState } from "react";
-import { Bookmark } from "src/core/domain/bookmark/bookmark";
-import BookmarkListItem from "./BookmarkListItem/BookmarkListItem";
+import React from "react";
 import styles from "./BookmarkList.module.css"
-import { Store } from "src/client/component/contentScript/App";
+import BookmarkListItem from "./BookmarkListItem/BookmarkListItem";
+import { useBookmarkListData } from "src/client/context/BookmarkList";
+import { useBookmarkOption } from "src/client/context/UiContext";
 
 const BookmarkList: React.FC = () => {
-  const [bookmarkList, setBookmarkList] = useState<Bookmark[] | Error>([]);
-  const {handleOpen, handleClose} = useContext(Store.BookmarkOption);
-
-  const init = () => {
-    // 북마크에 저장된 데이터 chrome storage 에서 불러오기
-    chrome.storage.local.get(['bookmark'], (result) => {
-      // storage 에서 불러온 데이터는 Object 형`태 => Bookmark 로 변환
-      const res = result.bookmark.map((e: { _parentId: string | undefined; _id: string | undefined; _title: string; _url: string | undefined; }) => new Bookmark(e._parentId, e._id, e._title, e._url));
-      setBookmarkList(res);
-    });
-  }
-
-  useEffect(() => {
-    init();
-  }, []);
+  const bookmarkList = useBookmarkListData();
+  const { toggleOpen } = useBookmarkOption();
 
   return (
     <ul className={styles.bookmarkList}>
-      <button onClick={init}>출력</button>
-      <button onClick={handleClose}>스크롤다운스크롤다운스크롤다운</button>
-      <button onClick={handleOpen}>스크롤업스크롤업스크롤업스크롤업</button>
+      <button onClick={toggleOpen}>스크롤토글</button>
       {bookmarkList instanceof Error ||
         bookmarkList
-          .filter((bookmark) => bookmark.url)
+          .filter((bookmark) => bookmark._url)
           .map((bookmark, idx) =>
-        (<BookmarkListItem key={`${idx}-${bookmark.id}-${bookmark.title}`} bookmark={bookmark} />)
+        (<BookmarkListItem key={`${idx}-${bookmark._id}-${bookmark._title}`} bookmark={bookmark} />)
       )}
     </ul>
   );

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkList/BookmarkListItem/BookmarkListItem.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkList/BookmarkListItem/BookmarkListItem.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Bookmark } from "src/core/domain/bookmark/bookmark";
 import styles from "./BookmarkListItem.module.css"
 import { AddIcon, DragIcon } from "src/client/component/Common/Icon";
 
@@ -8,14 +7,14 @@ type BookmarkListItemProps = {
 }
 
 const BookmarkListItem: React.FC<BookmarkListItemProps> = ({ bookmark }) => {
-  const url = `https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${bookmark.url}&size=16`;
+  const url = `https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${bookmark._url}&size=16`;
 
   return (
     <li className={styles.bookmarkListItem}>
-      <a href={bookmark.url} title={bookmark.title} target="_blank">
+      <a href={bookmark._url} title={bookmark._title} target="_blank">
         <div>
-          <img src={url} alt={bookmark.title} />
-          <span>{bookmark.title}</span>
+          <img src={url} alt={bookmark._title} />
+          <span>{bookmark._title}</span>
         </div>
       </a>
       <span><AddIcon size="18" /></span>

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkOption/BookmarkOption.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkOption/BookmarkOption.tsx
@@ -1,23 +1,27 @@
-import React, { useContext } from "react";
+import React from "react";
 import styles from './BookmarkOption.module.css';
 import Checkbox from "src/client/component/Common/Checkbox/Checkbox";
 import { ArrowIcon } from "src/client/component/Common/Icon";
-import { Store } from "src/client/component/contentScript/App";
+import { useBookmarkOption } from "src/client/context/UiContext";
+import { useBookmarkListState, useBookmarkListDispatch } from "src/client/context/BookmarkList";
 
 const BookmarkOption: React.FC = () => {
-  const { open, showFolder, orderBy, handleShowFolder, handleOrderBy } = useContext(Store.BookmarkOption);
+  const { open } = useBookmarkOption()
+  const { isFolder, orderBy } = useBookmarkListState();
+  const dispatch = useBookmarkListDispatch();
 
-
+  const toggleFolder = () => dispatch({ type: 'TOGGLE_FOLDER' });
+  const toggleOrderBy = () => dispatch({ type: "TOGGLE_ORDER_BY" });
 
   return (
     <div className={`${styles.bookmarkOption} ${open ? styles.open : ''}`}>
-      <a className={orderBy === "ASC" ? styles.asc : styles.desc} onClick={handleOrderBy}>
+      <a className={orderBy === "ASC" ? styles.asc : styles.desc} onClick={toggleOrderBy}>
         <ArrowIcon size="18" />
         <span>정렬</span>
       </a>
       <Checkbox
-        checked={showFolder}
-        onClick={handleShowFolder}
+        checked={isFolder}
+        onClick={toggleFolder}
         id="showFolder"
         text="폴더 보기"
       />

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkSidebar.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkSidebar.tsx
@@ -1,13 +1,13 @@
-import React, { useContext } from "react";
+import React from "react";
 import styles from "./BookmarkSidebar.module.css";
 import BookmarkHeader from "./BookmarkHeader/BookmarkHeader";
 import BookmarkList from "./BookmarkList/BookmarkList";
 import BookmarkOption from "./BookmarkOption/BookmarkOption";
 import Background from "src/client/component/Common/Background/Background"
-import { BookmarkSidebarOpen } from "src/client/component/contentScript/App";
+import { useBookmarkSidebar } from "src/client/context/UiContext";
 
 const BookmarkSidebar: React.FC = () => {
-  const { open, sidebarClose } = useContext(BookmarkSidebarOpen);
+  const { open, toggleOpen} = useBookmarkSidebar();
 
   return (
     <>
@@ -18,7 +18,7 @@ const BookmarkSidebar: React.FC = () => {
           <BookmarkList />
         </div>
       </aside>
-      <Background open={open} handleClose={sidebarClose} />
+      <Background open={open} handleClose={toggleOpen} />
     </>
   );
 };

--- a/src/client/context/BookmarkList/index.tsx
+++ b/src/client/context/BookmarkList/index.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, Dispatch, useEffect, useReducer, useState } from "react";
+import useBookmarkListData from './useBookmarkListData';
+import useBookmarkListState from './useBookmarkListState';
+import useBookmarkListDispatch from './useBookmarkListDispatch';
+
+type OrderBy = "ASC" | "DESC";
+type Index = Bookmark[] | BookmarkWithFolder[];
+type State = {
+  orderBy: OrderBy,
+  isFolder: boolean,
+  sortBy: string,
+  search: string
+};
+type Action = { type: "TOGGLE_ORDER_BY" } | { type: "TOGGLE_FOLDER" };
+type BookmarkListDispatch = Dispatch<Action>;
+
+export const BookmarkListData = createContext<Index | null>(null);
+export const BookmarkListState = createContext<State | null>(null);
+export const BookmarkListDispatch = createContext<BookmarkListDispatch | null>(null);
+
+const reducer = (state: State, action: Action): State => {
+  switch(action.type) {
+    case 'TOGGLE_FOLDER':
+      return {
+        ...state,
+        isFolder: !state.isFolder
+      }
+    case 'TOGGLE_ORDER_BY':
+      return state.orderBy === 'ASC'
+        ? { ...state, orderBy: 'DESC' }
+        : { ...state, orderBy: 'ASC' };
+    default:
+      throw new Error('non-existent type');
+  }
+}
+
+const BookmarkList: React.FC = ({ children}) => {
+  const [bookmarkList, setBookmarkList] = useState<Index>([]);
+  const [state, dispatch] = useReducer(reducer, {
+    isFolder: false,
+    orderBy: 'DESC',
+    sortBy: '정렬 방법은 고민중',
+    search: ''
+  });
+
+  const getBookmarkList = () => {
+    // 북마크에 저장된 데이터 chrome storage 에서 불러오기
+    chrome.storage.local.get(['bookmark'], (result) => {
+      // storage 에서 불러온 데이터는 Object 형`태 => Bookmark 로 변환
+      const res = result.bookmark.filter((e: Bookmark) => e._url);
+      setBookmarkList(res);
+    });
+  }
+
+  useEffect(() => {
+    if(!state.isFolder) {
+      getBookmarkList();
+    }
+  }, [state])
+
+  return (
+    <BookmarkListData.Provider value={bookmarkList}>
+      <BookmarkListState.Provider value={state}>
+        <BookmarkListDispatch.Provider value={dispatch}>
+          {children}
+        </BookmarkListDispatch.Provider>
+      </BookmarkListState.Provider>
+    </BookmarkListData.Provider>
+  );
+};
+
+export default BookmarkList;
+export { useBookmarkListData, useBookmarkListState, useBookmarkListDispatch };

--- a/src/client/context/BookmarkList/useBookmarkListData.ts
+++ b/src/client/context/BookmarkList/useBookmarkListData.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { BookmarkListData } from "src/client/context/BookmarkList/index";
+
+const useBookmarkListData = () => {
+  const data = useContext(BookmarkListData);
+  if (!data) throw new Error('Cannot find Provider');
+  return data;
+}
+
+export default useBookmarkListData;

--- a/src/client/context/BookmarkList/useBookmarkListDispatch.ts
+++ b/src/client/context/BookmarkList/useBookmarkListDispatch.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { BookmarkListDispatch } from "src/client/context/BookmarkList/index";
+
+const useBookmarkListDispatch = () => {
+  const dispatch = useContext(BookmarkListDispatch);
+  if (!dispatch) throw new Error('Cannot find Provider');
+  return dispatch;
+}
+
+export default useBookmarkListDispatch;

--- a/src/client/context/BookmarkList/useBookmarkListState.ts
+++ b/src/client/context/BookmarkList/useBookmarkListState.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { BookmarkListState } from "src/client/context/BookmarkList/index";
+
+const useBookmarkListState = () => {
+  const state = useContext(BookmarkListState);
+  if (!state) throw new Error('Cannot find Provider');
+  return state;
+}
+
+export default useBookmarkListState;

--- a/src/client/context/CombineProvider.tsx
+++ b/src/client/context/CombineProvider.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const CombineProvider = (...components: React.FC[]) => (
+  components.reduce((AccComponents, CurComponent) =>
+    ({ children }: { children: React.ReactNode }) => (
+      <AccComponents>
+        <CurComponent>
+          {children}
+        </CurComponent>
+      </AccComponents>
+    ), ({ children }: { children: React.ReactNode }) => <>{children}</>
+  )
+);
+
+export default CombineProvider;

--- a/src/client/context/UiContext/BookmarkOption.tsx
+++ b/src/client/context/UiContext/BookmarkOption.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useState } from "react";
+
+type Context = {
+  open: boolean;
+  toggleOpen(): void;
+}
+
+export const BookmarkOptionContext = createContext<Context>({} as Context);
+
+const BookmarkOption: React.FC = ({children}) => {
+  const [open, setOpen] = useState<boolean>(true);
+
+  const toggleOpen = () => {
+    setOpen(!open);
+  }
+
+  return (
+    <BookmarkOptionContext.Provider value={{open, toggleOpen}}>
+      {children}
+    </BookmarkOptionContext.Provider>
+  );
+};
+
+export default BookmarkOption;
+

--- a/src/client/context/UiContext/BookmarkSidebar.tsx
+++ b/src/client/context/UiContext/BookmarkSidebar.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useState } from "react";
+
+type Context = {
+  open: boolean;
+  toggleOpen(): void;
+}
+
+export const BookmarkSidebarContext = createContext<Context>({} as Context);
+
+const BookmarkSidebar: React.FC = ({children}) => {
+  const [open, setOpen] = useState<boolean>(false);
+
+  const toggleOpen = () => {
+    setOpen(!open);
+  }
+
+  return (
+    <BookmarkSidebarContext.Provider value={{open, toggleOpen}}>
+      {children}
+    </BookmarkSidebarContext.Provider>
+  );
+};
+
+export default BookmarkSidebar;
+

--- a/src/client/context/UiContext/index.tsx
+++ b/src/client/context/UiContext/index.tsx
@@ -1,0 +1,12 @@
+import BookmarkSidebar from "./BookmarkSidebar";
+import BookmarkOption from "src/client/context/UiContext/BookmarkOption";
+import useBookmarkSidebar from "./useBookmarkSidebar";
+import useBookmarkOption from "./useBookmarkOption";
+
+const providers = [
+  BookmarkSidebar,
+  BookmarkOption
+]
+
+export default providers;
+export { useBookmarkSidebar, useBookmarkOption }

--- a/src/client/context/UiContext/useBookmarkOption.ts
+++ b/src/client/context/UiContext/useBookmarkOption.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { BookmarkOptionContext } from "src/client/context/UiContext/BookmarkOption";
+
+const useBookmarkSidebar = () => {
+  const state = useContext(BookmarkOptionContext);
+  if (!state) throw new Error('Cannot find Provider');
+  return state;
+}
+
+export default useBookmarkSidebar;
+

--- a/src/client/context/UiContext/useBookmarkSidebar.ts
+++ b/src/client/context/UiContext/useBookmarkSidebar.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { BookmarkSidebarContext } from "src/client/context/UiContext/BookmarkSidebar";
+
+const useBookmarkSidebar = () => {
+  const state = useContext(BookmarkSidebarContext);
+  if (!state) throw new Error('Cannot find Provider');
+  return state;
+}
+
+export default useBookmarkSidebar;

--- a/src/client/context/index.tsx
+++ b/src/client/context/index.tsx
@@ -1,0 +1,12 @@
+import CombineProvider from "src/client/context/CombineProvider";
+import UiContext from "src/client/context/UiContext";
+import BookmarkList from "src/client/context/BookmarkList";
+import BookmarkSidebar from "src/client/context/UiContext/BookmarkSidebar";
+
+const providers = [
+  ...UiContext,
+  BookmarkList,
+  BookmarkSidebar
+]
+
+export const ContextProvider = CombineProvider(...providers);

--- a/src/client/type/Bookmark.ts
+++ b/src/client/type/Bookmark.ts
@@ -1,0 +1,10 @@
+type Bookmark = {
+  _parentId?: string;
+  _id?: string;
+  _title: string;
+  _url?: string;
+}
+
+type BookmarkWithFolder = Bookmark & {
+  _bookmark: Bookmark[];
+}


### PR DESCRIPTION
# Pull Request Check List

- Major Reviewer: @tooktak/clipbook 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context

#58 
`App.js` 에 작성된 global state 가 길어져 `src/context` 위치에 분리 시켰습니다. 
간단한(?) 작업 (ex. folder의 true, false 변경 or orderBy 의 'AEC', 'DESC' 변경 등 순수함수) 에 대해 useState 대신 useReducer 를 사용하였습니다. 
>https://github.com/tooktak/advanced-bookmark/pull/57 https://github.com/tooktak/advanced-bookmark/pull/56 https://github.com/tooktak/advanced-bookmark/pull/55 https://github.com/tooktak/advanced-bookmark/pull/54 https://github.com/tooktak/advanced-bookmark/pull/52 이후 작업입니다.
