### PR TITLE
Add scroll event with option

### DIFF
--- a/declaration.d.ts
+++ b/declaration.d.ts
@@ -3,3 +3,4 @@ declare module '*.module.css' {
   const classes: { [key: string]: string };
   export default classes;
 }
+declare module 'lodash-es';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "html-to-text": "^8.1.0",
+        "lodash-es": "^4.17.21",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
       },
@@ -4823,6 +4824,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -11082,6 +11088,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "html-to-text": "^8.1.0",
+    "lodash-es": "^4.17.21",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkList/BookmarkListItem/BookmarkListItem.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkList/BookmarkListItem/BookmarkListItem.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./BookmarkListItem.module.css"
 import { AddIcon, DragIcon } from "src/client/component/Common/Icon";
 
@@ -6,14 +6,27 @@ type BookmarkListItemProps = {
   bookmark: Bookmark;
 }
 
+const getFaviconUrl = (url: string | undefined) => `https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${url}&size=16`;
+
+
 const BookmarkListItem: React.FC<BookmarkListItemProps> = ({ bookmark }) => {
-  const url = `https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${bookmark._url}&size=16`;
+  const [favicon, setFavicon] = useState<string | undefined>();
+
+  const setValidFaviconUrl = (url: string | undefined) => {
+    const faviconUrl = getFaviconUrl(url);
+    fetch(faviconUrl)
+      .then((data) => data.ok ? setFavicon(data.url) : '');
+  }
+
+  useEffect(() => {
+    setValidFaviconUrl(bookmark._url);
+  }, [])
 
   return (
     <li className={styles.bookmarkListItem}>
       <a href={bookmark._url} title={bookmark._title} target="_blank">
         <div>
-          <img src={url} alt={bookmark._title} />
+          <img src={favicon} />
           <span>{bookmark._title}</span>
         </div>
       </a>

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkOption/BookmarkOption.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkOption/BookmarkOption.tsx
@@ -5,7 +5,11 @@ import { ArrowIcon } from "src/client/component/Common/Icon";
 import { useBookmarkOption } from "src/client/context/UiContext";
 import { useBookmarkListState, useBookmarkListDispatch } from "src/client/context/BookmarkList";
 
-const BookmarkOption: React.FC = () => {
+type BookmarkOptionProps = {
+  option: boolean
+}
+
+const BookmarkOption: React.FC<BookmarkOptionProps> = ({ option }) => {
   const { open } = useBookmarkOption()
   const { isFolder, orderBy } = useBookmarkListState();
   const dispatch = useBookmarkListDispatch();
@@ -14,7 +18,7 @@ const BookmarkOption: React.FC = () => {
   const toggleOrderBy = () => dispatch({ type: "TOGGLE_ORDER_BY" });
 
   return (
-    <div className={`${styles.bookmarkOption} ${open ? styles.open : ''}`}>
+    <div className={`${styles.bookmarkOption} ${option ? styles.open : ''}`}>
       <a className={orderBy === "ASC" ? styles.asc : styles.desc} onClick={toggleOrderBy}>
         <ArrowIcon size="18" />
         <span>정렬</span>

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkSidebar.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkSidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { UIEvent, useState } from "react";
 import styles from "./BookmarkSidebar.module.css";
 import BookmarkHeader from "./BookmarkHeader/BookmarkHeader";
 import BookmarkList from "./BookmarkList/BookmarkList";
@@ -6,16 +6,35 @@ import BookmarkOption from "./BookmarkOption/BookmarkOption";
 import Background from "src/client/component/Common/Background/Background"
 import { useBookmarkSidebar } from "src/client/context/UiContext";
 
+type Scroll = {
+  prev: number;
+  option: boolean;
+}
+
 const BookmarkSidebar: React.FC = () => {
+  const [scroll, setScroll] = useState<Scroll>({
+    prev: 0,
+    option: true
+  });
   const { open, handleSidebarClose } = useBookmarkSidebar();
+
+  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
+    const { scrollTop } = e.currentTarget;
+    const { prev } = scroll;
+    scrollTop > prev ? (
+      setScroll({ prev: scrollTop, option: false })
+    ) : (
+      setScroll({ prev: scrollTop, option: true })
+    )
+  }
 
   return (
     <>
       <Background open={open} handleClose={handleSidebarClose} />
       <aside className={styles.bookmarkSidebar}>
         <BookmarkHeader />
-        <BookmarkOption />
-        <div className={styles.listScroll}>
+        <BookmarkOption option={scroll.option} />
+        <div onScroll={handleScroll} className={styles.listScroll}>
           <BookmarkList />
         </div>
       </aside>

--- a/src/client/component/contentScript/BookmarkSidebar/BookmarkSidebar.tsx
+++ b/src/client/component/contentScript/BookmarkSidebar/BookmarkSidebar.tsx
@@ -1,40 +1,24 @@
-import React, { UIEvent, useState } from "react";
+import React, { useRef } from "react";
 import styles from "./BookmarkSidebar.module.css";
 import BookmarkHeader from "./BookmarkHeader/BookmarkHeader";
 import BookmarkList from "./BookmarkList/BookmarkList";
 import BookmarkOption from "./BookmarkOption/BookmarkOption";
 import Background from "src/client/component/Common/Background/Background"
 import { useBookmarkSidebar } from "src/client/context/UiContext";
-
-type Scroll = {
-  prev: number;
-  option: boolean;
-}
+import useOptionOpenWithScroll from "src/client/component/contentScript/BookmarkSidebar/useOptionOpenWithScroll";
 
 const BookmarkSidebar: React.FC = () => {
-  const [scroll, setScroll] = useState<Scroll>({
-    prev: 0,
-    option: true
-  });
   const { open, handleSidebarClose } = useBookmarkSidebar();
-
-  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
-    const { scrollTop } = e.currentTarget;
-    const { prev } = scroll;
-    scrollTop > prev ? (
-      setScroll({ prev: scrollTop, option: false })
-    ) : (
-      setScroll({ prev: scrollTop, option: true })
-    )
-  }
+  const bookmarkListRef = useRef<HTMLDivElement>(null);
+  const optionOpen = useOptionOpenWithScroll(bookmarkListRef, 200);
 
   return (
     <>
       <Background open={open} handleClose={handleSidebarClose} />
       <aside className={styles.bookmarkSidebar}>
         <BookmarkHeader />
-        <BookmarkOption option={scroll.option} />
-        <div onScroll={handleScroll} className={styles.listScroll}>
+        <BookmarkOption option={optionOpen} />
+        <div ref={bookmarkListRef} className={styles.listScroll}>
           <BookmarkList />
         </div>
       </aside>

--- a/src/client/component/contentScript/BookmarkSidebar/useOptionOpenWithScroll.ts
+++ b/src/client/component/contentScript/BookmarkSidebar/useOptionOpenWithScroll.ts
@@ -1,0 +1,32 @@
+import { RefObject, useEffect, useRef, useState } from "react";
+import { throttle } from "lodash-es";
+
+const useOptionOpenWithScroll = (domRef: RefObject<HTMLElement>, delay: number) => {
+  const [optionOpen, setOptionOpen] = useState<boolean>(true);
+  const prevScrollY = useRef<number>(0);
+
+  const scrollListener = () => {
+    if(domRef.current) {
+      const { scrollTop } = domRef.current;
+
+      if(prevScrollY.current < scrollTop && optionOpen) {
+        setOptionOpen(false);
+      }
+      if(prevScrollY.current > scrollTop && !optionOpen) {
+        setOptionOpen(true);
+      }
+      prevScrollY.current = scrollTop;
+    }
+  }
+
+  const throttleScrollListener = throttle(scrollListener, delay);
+
+  useEffect(() => {
+    domRef.current?.addEventListener('scroll', throttleScrollListener);
+    return () => domRef.current?.removeEventListener('scroll', throttleScrollListener);
+  }, [optionOpen]);
+
+  return optionOpen;
+};
+
+export default useOptionOpenWithScroll;

--- a/src/client/context/BookmarkList/index.tsx
+++ b/src/client/context/BookmarkList/index.tsx
@@ -4,7 +4,7 @@ import useBookmarkListState from './useBookmarkListState';
 import useBookmarkListDispatch from './useBookmarkListDispatch';
 
 type OrderBy = "ASC" | "DESC";
-type Index = Bookmark[] | BookmarkWithFolder[];
+type BookmarkList = Bookmark[] | BookmarkWithFolder[];
 type State = {
   orderBy: OrderBy,
   isFolder: boolean,
@@ -14,7 +14,7 @@ type State = {
 type Action = { type: "TOGGLE_ORDER_BY" } | { type: "TOGGLE_FOLDER" };
 type BookmarkListDispatch = Dispatch<Action>;
 
-export const BookmarkListData = createContext<Index | null>(null);
+export const BookmarkListData = createContext<BookmarkList | null>(null);
 export const BookmarkListState = createContext<State | null>(null);
 export const BookmarkListDispatch = createContext<BookmarkListDispatch | null>(null);
 
@@ -35,7 +35,7 @@ const reducer = (state: State, action: Action): State => {
 }
 
 const BookmarkList: React.FC = ({ children}) => {
-  const [bookmarkList, setBookmarkList] = useState<Index>([]);
+  const [bookmarkList, setBookmarkList] = useState<BookmarkList>([]);
   const [state, dispatch] = useReducer(reducer, {
     isFolder: false,
     orderBy: 'DESC',
@@ -56,6 +56,7 @@ const BookmarkList: React.FC = ({ children}) => {
     if(!state.isFolder) {
       getBookmarkList();
     }
+    console.log(bookmarkList);
   }, [state])
 
   return (


### PR DESCRIPTION
# Pull Request Check List

- Major Reviewer: @tooktak/clipbook 

## CheckList

- [ ] Unit test coverage
- [ ] Backward compatibility
- [ ] Tested on dev/staging environment
- [ ] Documentation
- [x] Self reviewed

## Context

- `favicon` 불러오는 형식 변경 (브랜치로 따로 나누지 않아 부득이하게 같이 올림 ... ㅎ)
- 일부 변수 명 변경
- `bookmarkList` 영역에서 **스크롤 down 시 Option 을 open 하고, 스크롤 up 시 Option 을 close** 함
- `스크롤 event listener` 에서 연산이 너무 빠르게 많이 일어나 `throttle` 함수 추가
  - `throttle`: 마지막 함수가 호출된 후 일정 시간이 지나기 전 다시 호출하지 않게 함
  - `debounce`: 호출되는 함수들 중 마지막 함수만 호출
- `throttle` 은 `lodash` 라이브러리 사용
  - `lodash` 자체는 `es6` 로 작성되어있지 않아 `tree shaking` 이 일어나지 않음 => `lodash-es` 사용
    - `tree shaking` 은 간단하게 말해서 사용하지 않는 코드를 삭제하는 것
  - lodash 라이브러리를 그냥 설치하면 ts 로 작성되어있지 않아 `error` 발생
    - `declare` 추가
    - `@types/lodash-es` 설치
- 스크롤 이벤트 리스너가 발생되는 부분 `customhook` 으로 분리
  - `useOptionOpenWithScroll`
  - 커스텀훅을 더 분리할 수 있을 것 같긴 한데 다른 곳에서 사용할 일이 아직은 없을 것 같아 나누진 않음
